### PR TITLE
Parse the data descriptor section

### DIFF
--- a/src/main/java/software/coley/llzip/format/ZipPatterns.java
+++ b/src/main/java/software/coley/llzip/format/ZipPatterns.java
@@ -43,4 +43,12 @@ public interface ZipPatterns {
 	 * Header for {@link EndOfCentralDirectory}, as a {@code s4/quad/int}
 	 */
 	int END_OF_CENTRAL_DIRECTORY_QUAD = 0x06_05_4B_50;
+	/**
+	 * Option header for the data descriptor section
+	 */
+	int[] DATA_DESCRIPTOR = {0x08, 0x07, 0x4b, 0x50};
+	/**
+	 * Option header for the data descriptor section, as a {@code s4/quad/int}
+	 */
+	int DATA_DESCRIPTOR_QUAD = 0x08_07_4b_50;
 }

--- a/src/main/java/software/coley/llzip/format/model/AbstractZipFileHeader.java
+++ b/src/main/java/software/coley/llzip/format/model/AbstractZipFileHeader.java
@@ -286,6 +286,14 @@ public abstract class AbstractZipFileHeader implements ZipPart, ZipRead {
 		});
 	}
 
+	protected LazyInt readQuad(ByteData data, LazyLong localOffset) {
+		return new LazyInt(() -> {
+			if (data.isClosed())
+				throw new IllegalStateException("Cannot read from closed data source");
+			return ByteDataUtil.readQuad(data, offset + localOffset.get());
+		});
+	}
+
 	protected LazyInt readMaskedQuad(ByteData data, int localOffset) {
 		return new LazyInt(() -> {
 			if (data.isClosed())
@@ -307,6 +315,14 @@ public abstract class AbstractZipFileHeader implements ZipPart, ZipRead {
 			if (data.isClosed())
 				throw new IllegalStateException("Cannot read from closed data source");
 			return ByteDataUtil.readQuad(data, offset + localOffset) & 0xFFFFFFFFL;
+		});
+	}
+
+	protected LazyLong readMaskedLongQuad(ByteData data, LazyLong localOffset) {
+		return new LazyLong(() -> {
+			if (data.isClosed())
+				throw new IllegalStateException("Cannot read from closed data source");
+			return ByteDataUtil.readQuad(data, offset + localOffset.get()) & 0xFFFFFFFFL;
 		});
 	}
 

--- a/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
+++ b/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
@@ -38,10 +38,9 @@ public class JvmLocalFileHeader extends LocalFileHeader {
 		// JVM file data reading does NOT use the compressed/uncompressed fields.
 		// Instead, it scans data until the next header.
 		long dataOffsetStart = offset + MIN_FIXED_SIZE + getFileNameLength() + getExtraFieldLength();
-		// Subtract the length of the data descriptor section from the data end offset
-		int dataDescLength = this.dataDescLength.get();
 		final Long rawDataOffsetEnd = offsets.ceiling(dataOffsetStart);
-		final Long dataOffsetEnd = rawDataOffsetEnd != null ? rawDataOffsetEnd - dataDescLength : null;
+		// Subtract the length of the data descriptor section from the data end offset
+		final Long dataOffsetEnd = rawDataOffsetEnd != null ? rawDataOffsetEnd - this.dataDescLength.get() : null;
 		this.dataOffsetStart = dataOffsetStart;
 		this.dataOffsetEnd = dataOffsetEnd == null ? -1 : dataOffsetEnd;
 		if (dataOffsetEnd != null) {

--- a/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
+++ b/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
@@ -1,5 +1,6 @@
 package software.coley.llzip.format.model;
 
+import software.coley.llzip.format.ZipPatterns;
 import software.coley.llzip.format.compression.ZipCompressions;
 import software.coley.llzip.util.ByteData;
 import software.coley.llzip.util.lazy.LazyInt;
@@ -37,7 +38,17 @@ public class JvmLocalFileHeader extends LocalFileHeader {
 		// JVM file data reading does NOT use the compressed/uncompressed fields.
 		// Instead, it scans data until the next header.
 		long dataOffsetStart = offset + MIN_FIXED_SIZE + getFileNameLength() + getExtraFieldLength();
-		Long dataOffsetEnd = offsets.ceiling(dataOffsetStart);
+		// Subtract the length of the data descriptor section from the data end offset
+		int dataDescLength = 0;
+		if ((getGeneralPurposeBitFlag() & 8) == 8) {
+			dataDescLength = 12;
+
+			if (data.getInt(offset) == ZipPatterns.DATA_DESCRIPTOR_QUAD) {
+				dataDescLength += 4;
+			}
+		}
+		// "Effectively final"
+		Long dataOffsetEnd = ((dataOffsetEnd = offsets.ceiling(dataOffsetStart)) != null) ? dataOffsetEnd - dataDescLength : null;
 		this.dataOffsetStart = dataOffsetStart;
 		this.dataOffsetEnd = dataOffsetEnd == null ? -1 : dataOffsetEnd;
 		if (dataOffsetEnd != null) {

--- a/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
+++ b/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
@@ -40,8 +40,8 @@ public class JvmLocalFileHeader extends LocalFileHeader {
 		long dataOffsetStart = offset + MIN_FIXED_SIZE + getFileNameLength() + getExtraFieldLength();
 		// Subtract the length of the data descriptor section from the data end offset
 		int dataDescLength = this.dataDescLength.get();
-		// "Effectively final"
-		Long dataOffsetEnd = ((dataOffsetEnd = offsets.ceiling(dataOffsetStart)) != null) ? dataOffsetEnd - dataDescLength : null;
+		final Long rawDataOffsetEnd = offsets.ceiling(dataOffsetStart);
+		final Long dataOffsetEnd = rawDataOffsetEnd != null ? rawDataOffsetEnd - dataDescLength : null;
 		this.dataOffsetStart = dataOffsetStart;
 		this.dataOffsetEnd = dataOffsetEnd == null ? -1 : dataOffsetEnd;
 		if (dataOffsetEnd != null) {

--- a/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
+++ b/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
@@ -39,14 +39,7 @@ public class JvmLocalFileHeader extends LocalFileHeader {
 		// Instead, it scans data until the next header.
 		long dataOffsetStart = offset + MIN_FIXED_SIZE + getFileNameLength() + getExtraFieldLength();
 		// Subtract the length of the data descriptor section from the data end offset
-		int dataDescLength = 0;
-		if ((getGeneralPurposeBitFlag() & 8) == 8) {
-			dataDescLength = 12;
-
-			if (data.getInt(offset) == ZipPatterns.DATA_DESCRIPTOR_QUAD) {
-				dataDescLength += 4;
-			}
-		}
+		int dataDescLength = this.dataDescLength.get();
 		// "Effectively final"
 		Long dataOffsetEnd = ((dataOffsetEnd = offsets.ceiling(dataOffsetStart)) != null) ? dataOffsetEnd - dataDescLength : null;
 		this.dataOffsetStart = dataOffsetStart;

--- a/src/main/java/software/coley/llzip/util/lazy/LazyLong.java
+++ b/src/main/java/software/coley/llzip/util/lazy/LazyLong.java
@@ -16,6 +16,10 @@ public class LazyLong extends Lazy<LongSupplier> {
 		super(lookup);
 	}
 
+	public LazyLong add(long value) {
+		return new LazyLong(() -> value + lookup.getAsLong());
+	}
+
 	/**
 	 * @param value
 	 * 		Long value.


### PR DESCRIPTION
~Fixes #17. Parses the data descriptor section and reads values for its fields, and takes the length of the data descriptor section into account when parsing local file headers with JvmLocalFileHeader.~

I've realised that my approach is highly flawed.