### PR TITLE
Fix end of file offset in JvmLocalFileHeader when reading files with data descriptor

### DIFF
--- a/src/main/java/software/coley/llzip/format/ZipPatterns.java
+++ b/src/main/java/software/coley/llzip/format/ZipPatterns.java
@@ -43,4 +43,12 @@ public interface ZipPatterns {
 	 * Header for {@link EndOfCentralDirectory}, as a {@code s4/quad/int}
 	 */
 	int END_OF_CENTRAL_DIRECTORY_QUAD = 0x06_05_4B_50;
+	/**
+	 * Option header for the data descriptor section
+	 */
+	int[] DATA_DESCRIPTOR = {0x08, 0x07, 0x4b, 0x50};
+	/**
+	 * Option header for the data descriptor section, as a {@code s4/quad/int}
+	 */
+	int DATA_DESCRIPTOR_QUAD = 0x08_07_4b_50;
 }

--- a/src/main/java/software/coley/llzip/format/ZipPatterns.java
+++ b/src/main/java/software/coley/llzip/format/ZipPatterns.java
@@ -44,11 +44,11 @@ public interface ZipPatterns {
 	 */
 	int END_OF_CENTRAL_DIRECTORY_QUAD = 0x06_05_4B_50;
 	/**
-	 * Option header for the data descriptor section
+	 * Optional header for the data descriptor section
 	 */
 	int[] DATA_DESCRIPTOR = {0x08, 0x07, 0x4b, 0x50};
 	/**
-	 * Option header for the data descriptor section, as a {@code s4/quad/int}
+	 * Optional header for the data descriptor section, as a {@code s4/quad/int}
 	 */
 	int DATA_DESCRIPTOR_QUAD = 0x08_07_4b_50;
 }

--- a/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
+++ b/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
@@ -41,10 +41,10 @@ public class JvmLocalFileHeader extends LocalFileHeader {
 		final Long rawDataOffsetEnd = offsets.ceiling(dataOffsetStart);
 		// Subtract the length of the data descriptor section from the data end offset
 		int dataDescLength = 0;
-		if ((getGeneralPurposeBitFlag() & 8) == 8) {
+		if (rawDataOffsetEnd != null && (getGeneralPurposeBitFlag() & 8) == 8) {
 			dataDescLength = 12;
 
-			if (data.getInt(offset) == ZipPatterns.DATA_DESCRIPTOR_QUAD) {
+			if (data.getInt(rawDataOffsetEnd - 16) == ZipPatterns.DATA_DESCRIPTOR_QUAD) {
 				dataDescLength += 4;
 			}
 		}

--- a/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
+++ b/src/main/java/software/coley/llzip/format/model/JvmLocalFileHeader.java
@@ -38,17 +38,16 @@ public class JvmLocalFileHeader extends LocalFileHeader {
 		// JVM file data reading does NOT use the compressed/uncompressed fields.
 		// Instead, it scans data until the next header.
 		long dataOffsetStart = offset + MIN_FIXED_SIZE + getFileNameLength() + getExtraFieldLength();
-		final Long rawDataOffsetEnd = offsets.ceiling(dataOffsetStart);
+		Long rawDataOffsetEnd = offsets.ceiling(dataOffsetStart);
 		// Subtract the length of the data descriptor section from the data end offset
-		int dataDescLength = 0;
 		if (rawDataOffsetEnd != null && (getGeneralPurposeBitFlag() & 8) == 8) {
-			dataDescLength = 12;
+			rawDataOffsetEnd -= 12;
 
-			if (data.getInt(rawDataOffsetEnd - 16) == ZipPatterns.DATA_DESCRIPTOR_QUAD) {
-				dataDescLength += 4;
+			if (data.getInt(rawDataOffsetEnd - 4) == ZipPatterns.DATA_DESCRIPTOR_QUAD) {
+				rawDataOffsetEnd -= 4;
 			}
 		}
-		final Long dataOffsetEnd = rawDataOffsetEnd != null ? rawDataOffsetEnd - dataDescLength : null;
+		final Long dataOffsetEnd = rawDataOffsetEnd;
 		this.dataOffsetStart = dataOffsetStart;
 		this.dataOffsetEnd = dataOffsetEnd == null ? -1 : dataOffsetEnd;
 		if (dataOffsetEnd != null) {


### PR DESCRIPTION
This only takes the offset into account, the data descriptor is not parsed.