### PR TITLE
Another ByteBuffer.position java 1.8 bug

### DIFF
--- a/src/main/java/software/coley/lljzip/util/ByteDataUtil.java
+++ b/src/main/java/software/coley/lljzip/util/ByteDataUtil.java
@@ -5,6 +5,7 @@ import software.coley.lljzip.util.lazy.LazyByteData;
 import software.coley.lljzip.util.lazy.LazyInt;
 import software.coley.lljzip.util.lazy.LazyLong;
 
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
@@ -297,7 +298,7 @@ public class ByteDataUtil {
 	 */
 	public static ByteBuffer sliceExact(ByteBuffer data, int start, int end) {
 		ByteBuffer slice = data.slice();
-		slice = ((ByteBuffer) slice.position(start)).slice();
+		slice = ((ByteBuffer) ((Buffer)slice).position(start)).slice();
 		slice.limit(end - start);
 		return slice.order(data.order());
 	}


### PR DESCRIPTION
running on java 1.8 if compiled on java 17 results in a NoSuchMethodError  
Why: https://gist.github.com/KosmX/e8792213a0e7920a849351c2693a257f