### PR TITLE
Reconcile getFileName() documentation of the file headers

### DIFF
--- a/src/main/java/software/coley/lljzip/format/model/AbstractZipFileHeader.java
+++ b/src/main/java/software/coley/lljzip/format/model/AbstractZipFileHeader.java
@@ -225,8 +225,9 @@ public abstract class AbstractZipFileHeader implements ZipPart, ZipRead {
 	}
 
 	/**
-	 * Should match {@link LocalFileHeader#getFileName()} but is not a strict requirement.
-	 * If they do not match, trust this value instead.
+	 * The return value of the CentralDirectoryFileHeader should match the file name of the
+	 * LocalFileHeader but is not a strict requirement.
+	 * If they do not match, the central directory file name should be trusted instead.
 	 *
 	 * @return File name.
 	 */
@@ -244,7 +245,8 @@ public abstract class AbstractZipFileHeader implements ZipPart, ZipRead {
 	}
 
 	/**
-	 * Should match {@link CentralDirectoryFileHeader#getFileName()} but is not a strict requirement.
+	 * The return value of the CentralDirectoryFileHeader should match the file name of the
+	 * LocalFileHeader but is not a strict requirement.
 	 * If they do not match, the central directory file name should be trusted instead.
 	 *
 	 * @return File name.


### PR DESCRIPTION
Nothing major - just documentation changes. It seems as if the javadocs were carried over from their original class without change when the AbstractZipFileHeader class was made, which made the wording of the documentation be misleading. By using more generic wording, this should be resolved.