### PR TITLE
fix: update offset increment in AdaptingZipReader buffer loop

### DIFF
--- a/src/main/java/software/coley/lljzip/format/read/AdaptingZipReader.java
+++ b/src/main/java/software/coley/lljzip/format/read/AdaptingZipReader.java
@@ -38,7 +38,7 @@ public class AdaptingZipReader implements ZipReader {
 					int copyable = (int) Math.min(BUFFER_SIZE, length - offset);
 					MemorySegment.copy(data, offset, wrapper, 0, copyable);
 					os.write(buf, 0, copyable);
-					offset += length;
+					offset += copyable;
 				}
 			}
 			fill(zip, temp);

--- a/src/test/java/software/coley/lljzip/AdaptingZipReaderTests.java
+++ b/src/test/java/software/coley/lljzip/AdaptingZipReaderTests.java
@@ -1,0 +1,52 @@
+package software.coley.lljzip;
+
+import org.junit.jupiter.api.Test;
+import software.coley.lljzip.format.model.ZipArchive;
+import software.coley.lljzip.format.read.AdaptingZipReader;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.zip.CRC32;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Tests for {@link AdaptingZipReader} targeting buffer loop regressions.
+ *
+ * @author TheWakz
+ */
+public class AdaptingZipReaderTests {
+
+    @Test
+    public void testReadArchiveExceedingBufferSize() throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (ZipOutputStream zos = new ZipOutputStream(baos)) {
+            byte[] dummyData = new byte[20 * 1024];
+
+            ZipEntry entry = new ZipEntry("large_entry.txt");
+            entry.setMethod(ZipEntry.STORED);
+            entry.setSize(dummyData.length);
+            entry.setCompressedSize(dummyData.length);
+
+            CRC32 crc = new CRC32();
+            crc.update(dummyData);
+            entry.setCrc(crc.getValue());
+
+            zos.putNextEntry(entry);
+            zos.write(dummyData);
+            zos.closeEntry();
+        }
+        byte[] zipBytes = baos.toByteArray();
+
+        assertTrue(zipBytes.length > 16384, "Test archive size must exceed 16KB");
+
+        ZipArchive archive = assertDoesNotThrow(() -> ZipIO.read(zipBytes, new AdaptingZipReader()),
+                "Failed to read with read(adapting) when size exceeds buffer");
+
+        assertNotNull(archive, "Archive is null");
+        assertNotNull(archive.getLocalFileByName("large_entry.txt"),
+                "Missing 'large_entry.txt' file due to truncation");
+    }
+}


### PR DESCRIPTION
### Description
Fixes a bug in `AdaptingZipReader` where the buffer loop offset was incorrectly incremented by the total `length` instead of the current `copyable` block size.

### Defect
For any ZIP data payload exceeding the `BUFFER_SIZE` (16KB), the loop would prematurely terminate after the first iteration. This caused truncated temporary files to be written to disk, leading to subsequent parser failures (such as unexpected EOF or bad header sizes) when the standard `ZipFile` tried to process them.

### Fix
Changed `offset += length;` to `offset += copyable;` to ensure the loop correctly and fully iterates through the entire `MemorySegment`.